### PR TITLE
[feature] Split python vim settings into its own module

### DIFF
--- a/.vim/ftplugin/python.vim
+++ b/.vim/ftplugin/python.vim
@@ -1,0 +1,2 @@
+set colorcolumn=73,80
+let python_highlight_all = 1

--- a/.vimrc
+++ b/.vimrc
@@ -1,7 +1,6 @@
 set number
 set backspace=indent,eol,start
-set colorcolumn=79
-filetype plugin on
+filetype plugin indent on
 syntax on
 colorscheme sublime
 set expandtab


### PR DESCRIPTION
Moved my python vim settings specific to python to the
ftplugin/python.vim file. This should keep global settings unique for
other file types.